### PR TITLE
Add script to find Instagram accounts not following back

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Insta AntiDoom
+
+This repository contains a simple tool to list all Instagram accounts that you follow but which do not follow you back.
+
+## Requirements
+- Python 3.8+
+- [instaloader](https://instaloader.github.io/) (installed automatically via `requirements.txt`)
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python find_unfollowers.py -u YOUR_USERNAME -p YOUR_PASSWORD
+```
+
+If you prefer not to pass the password via command line, set it in the environment variable `INSTAGRAM_PASS` and omit `-p`.
+
+The script will output a list of usernames, one per line, representing accounts you follow that do not follow you back.

--- a/find_unfollowers.py
+++ b/find_unfollowers.py
@@ -1,0 +1,38 @@
+import argparse
+import instaloader
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Find accounts you follow that don't follow you back")
+    parser.add_argument('-u', '--username', required=True, help='Your Instagram username')
+    parser.add_argument('-p', '--password', help='Your Instagram password (or set INSTAGRAM_PASS env variable)')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    password = args.password
+    if password is None:
+        import os
+        password = os.getenv('INSTAGRAM_PASS')
+        if password is None:
+            raise SystemExit('Password not provided via argument or INSTAGRAM_PASS env variable')
+
+    L = instaloader.Instaloader()
+    try:
+        L.login(args.username, password)
+    except Exception as e:
+        raise SystemExit(f'Login failed: {e}')
+
+    profile = instaloader.Profile.from_username(L.context, args.username)
+
+    followers = {follower.username for follower in profile.get_followers()}
+    followees = {followee.username for followee in profile.get_followees()}
+
+    not_following_back = sorted(followees - followers)
+
+    print('\n'.join(not_following_back))
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+instaloader>=4.10


### PR DESCRIPTION
## Summary
- create `find_unfollowers.py` for checking which followed accounts don't follow back
- add usage documentation
- include `requirements.txt` with instaloader dependency

## Testing
- `python -m pip install -r requirements.txt`
- `python find_unfollowers.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6867ea2bf5e483309aaa694843250882